### PR TITLE
Use Increment() instead of _result++ in C# code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Incrementers/issues/38
+Your prepared branch: issue-38-f52ecf64
+Your prepared working directory: /tmp/gh-issue-solver-1757742500093
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Incrementers/issues/38
-Your prepared branch: issue-38-f52ecf64
-Your prepared working directory: /tmp/gh-issue-solver-1757742500093
-
-Proceed.

--- a/csharp/Platform.Incrementers/Incrementer[TValue, TDecision].cs
+++ b/csharp/Platform.Incrementers/Incrementer[TValue, TDecision].cs
@@ -68,7 +68,7 @@ namespace Platform.Incrementers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TDecision IncrementAndReturnTrue()
         {
-            _result++;
+            Increment();
             return _trueValue;
         }
 
@@ -89,7 +89,7 @@ namespace Platform.Incrementers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TDecision IncrementAndReturnTrue(TValue value)
         {
-            _result++;
+            Increment();
             return _trueValue;
         }
     }


### PR DESCRIPTION
## Summary
This PR addresses issue #38 by replacing direct `_result++` increments with calls to the `Increment()` method in the `IncrementAndReturnTrue` methods.

## Changes Made
- Replaced `_result++` with `Increment()` in `IncrementAndReturnTrue()` method (line 71)
- Replaced `_result++` with `Increment()` in `IncrementAndReturnTrue(TValue value)` method (line 92)
- Maintained the same functionality while using the proper abstraction

## Test Results
All existing tests continue to pass:
- ParameterlessConstructedSetterTest ✓
- ConstructedWithDefaultValueSetterTest ✓  
- MethodsWithBooleanReturnTypeTest ✓
- MethodsWithIntegerReturnTypeTest ✓

The change ensures that incrementing behavior is consistently handled through the `Increment()` method rather than direct field manipulation.

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)